### PR TITLE
Get Reports for Organization details feature in Aggregator #143

### DIFF
--- a/src/1-BuildingBlocks/Contracts/Dtos/Tasks/GetTaskDto.cs
+++ b/src/1-BuildingBlocks/Contracts/Dtos/Tasks/GetTaskDto.cs
@@ -1,5 +1,6 @@
 ﻿using System.ComponentModel.DataAnnotations;
 using TaskoMask.BuildingBlocks.Contracts.Dtos.Common;
+using TaskoMask.BuildingBlocks.Contracts.Enums;
 using TaskoMask.BuildingBlocks.Contracts.Resources;
 
 namespace TaskoMask.BuildingBlocks.Contracts.Dtos.Tasks;
@@ -8,6 +9,7 @@ public class GetTaskDto : TaskBaseDto
 {
     [Display(Name = nameof(ContractsMetadata.OrganizationName), ResourceType = typeof(ContractsMetadata))]
     public string CardName { get; set; }
+    public BoardCardType CardType { get; set; }
 
     public string BoardId { get; set; }
 

--- a/src/1-BuildingBlocks/Contracts/Protos/base.proto
+++ b/src/1-BuildingBlocks/Contracts/Protos/base.proto
@@ -65,4 +65,14 @@ message GetCardGrpcResponse {
 	string ownerId = 8;
 }
 
+message GetOrganizationReportGrpcResponse {
 
+	CreationTimeGrpcResponse creationTime=1;
+	string projectsCount = 2;
+	string boardsCount = 3;
+	string toDoTasksCount = 4;
+	string doingTasksCount = 5;
+	string doneTasksCount = 6;
+	string backlogTasksCount = 7;
+	string id = 8;
+}

--- a/src/1-BuildingBlocks/Contracts/Protos/get_organizationReport_by_id.proto
+++ b/src/1-BuildingBlocks/Contracts/Protos/get_organizationReport_by_id.proto
@@ -1,0 +1,13 @@
+﻿syntax = "proto3";
+
+package TaskoMask.BuildingBlocks.Contracts.Protos;
+
+import "base.proto";
+
+service GetOrganizationReportIdGrpcService {
+  rpc Handle (GetOrganizationReportIdGrpcRequest) returns (GetOrganizationReportGrpcResponse);
+}
+
+message GetOrganizationReportIdGrpcRequest {
+  string organizationId = 1;
+}

--- a/src/2-Services/Owners/Api/Owners.Read.Api/Configuration/GrpcExtensions.cs
+++ b/src/2-Services/Owners/Api/Owners.Read.Api/Configuration/GrpcExtensions.cs
@@ -1,5 +1,10 @@
 ﻿using Microsoft.AspNetCore.Builder;
 using Microsoft.AspNetCore.Routing;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.DependencyInjection;
+using System;
+using TaskoMask.BuildingBlocks.Contracts.Protos;
+using TaskoMask.Services.Owners.Read.Api.Features.Organizations.GetOrganizationReportById;
 using TaskoMask.Services.Owners.Read.Api.Features.Organizations.GetOrganizationsByOwnerId;
 using TaskoMask.Services.Owners.Read.Api.Features.Projects.GetProjectById;
 using TaskoMask.Services.Owners.Read.Api.Features.Projects.GetProjectsByOrganizationId;
@@ -16,5 +21,26 @@ public static class GrpcExtensions
         endpoints.MapGrpcService<GetOrganizationsByOwnerIdGrpcEndpoint>();
         endpoints.MapGrpcService<GetProjectsByOrganizationIdGrpcEndpoint>();
         endpoints.MapGrpcService<GetProjectByIdGrpcEndpoint>();
+        endpoints.MapGrpcService<GetOrganizationReportByIdGrpcEndpoint>();
+    }
+
+
+    public static void AddGrpcClients(this IServiceCollection services, IConfiguration configuration)
+    {
+        services.AddGrpcClient<GetBoardsByOrganizationIdGrpcService.GetBoardsByOrganizationIdGrpcServiceClient>(options =>
+        {
+            options.Address = new Uri(configuration["Url:Board-Read-Service"]);
+        });
+
+        services.AddGrpcClient<GetCardsByBoardIdGrpcService.GetCardsByBoardIdGrpcServiceClient>(options =>
+        {
+            options.Address = new Uri(configuration["Url:Board-Read-Service"]);
+        });
+
+        services.AddGrpcClient<GetTasksByCardIdGrpcService.GetTasksByCardIdGrpcServiceClient>(options =>
+        {
+            options.Address = new Uri(configuration["Url:Task-Read-Service"]);
+        });
+
     }
 }

--- a/src/2-Services/Owners/Api/Owners.Read.Api/Configuration/HostingExtensions.cs
+++ b/src/2-Services/Owners/Api/Owners.Read.Api/Configuration/HostingExtensions.cs
@@ -24,6 +24,8 @@ internal static class HostingExtensions
 
         builder.Services.AddGrpcPreConfigured();
 
+        builder.Services.AddGrpcClients(builder.Configuration);
+
         return builder.Build();
     }
 

--- a/src/2-Services/Owners/Api/Owners.Read.Api/Features/Organizations/GetOrganizationReportById/GetOrganizationReportByIdGrpcEndpoint.cs
+++ b/src/2-Services/Owners/Api/Owners.Read.Api/Features/Organizations/GetOrganizationReportById/GetOrganizationReportByIdGrpcEndpoint.cs
@@ -1,0 +1,26 @@
+﻿using AutoMapper;
+using Grpc.Core;
+using System.Threading.Tasks;
+using TaskoMask.BuildingBlocks.Application.Bus;
+using TaskoMask.BuildingBlocks.Contracts.Protos;
+
+namespace TaskoMask.Services.Owners.Read.Api.Features.Organizations.GetOrganizationReportById;
+
+
+public class GetOrganizationReportByIdGrpcEndpoint : GetOrganizationReportIdGrpcService.GetOrganizationReportIdGrpcServiceBase
+{
+    private readonly IInMemoryBus _inMemoryBus;
+    private readonly IMapper _mapper;
+
+    public GetOrganizationReportByIdGrpcEndpoint(IInMemoryBus inMemoryBus, IMapper mapper)
+    {
+        _inMemoryBus = inMemoryBus;
+        _mapper = mapper;
+    }
+
+    public override async Task<GetOrganizationReportGrpcResponse> Handle(GetOrganizationReportIdGrpcRequest request, ServerCallContext context)
+    {
+        var report = await _inMemoryBus.SendQuery(new GetOrganizationReportByIdRequest(request.OrganizationId));
+        return _mapper.Map<GetOrganizationReportGrpcResponse>(report.Value);
+    }
+}

--- a/src/2-Services/Owners/Api/Owners.Read.Api/Features/Organizations/GetOrganizationReportById/GetOrganizationReportByIdHandler.cs
+++ b/src/2-Services/Owners/Api/Owners.Read.Api/Features/Organizations/GetOrganizationReportById/GetOrganizationReportByIdHandler.cs
@@ -1,0 +1,207 @@
+﻿using AutoMapper;
+using Grpc.Core;
+using MediatR;
+using MongoDB.Driver;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using TaskoMask.BuildingBlocks.Application.Exceptions;
+using TaskoMask.BuildingBlocks.Application.Queries;
+using TaskoMask.BuildingBlocks.Contracts.Dtos.Boards;
+using TaskoMask.BuildingBlocks.Contracts.Dtos.Cards;
+using TaskoMask.BuildingBlocks.Contracts.Dtos.Organizations;
+using TaskoMask.BuildingBlocks.Contracts.Dtos.Tasks;
+using TaskoMask.BuildingBlocks.Contracts.Enums;
+using TaskoMask.BuildingBlocks.Contracts.Protos;
+using TaskoMask.BuildingBlocks.Contracts.Resources;
+using TaskoMask.BuildingBlocks.Contracts.ViewModels;
+using TaskoMask.BuildingBlocks.Domain.Resources;
+using TaskoMask.Services.Owners.Read.Api.Infrastructure.DbContext;
+using static TaskoMask.BuildingBlocks.Contracts.Protos.GetBoardsByOrganizationIdGrpcService;
+using static TaskoMask.BuildingBlocks.Contracts.Protos.GetCardsByBoardIdGrpcService;
+using static TaskoMask.BuildingBlocks.Contracts.Protos.GetTasksByCardIdGrpcService;
+
+
+namespace TaskoMask.Services.Owners.Read.Api.Features.Organizations.GetOrganizationReportById;
+
+public class GetOrganizationReportByIdHandler : BaseQueryHandler, IRequestHandler<GetOrganizationReportByIdRequest, OrganizationReportDto>
+{
+    #region Fields
+
+    private readonly OwnerReadDbContext _ownerReadDbContext;
+    private readonly GetBoardsByOrganizationIdGrpcServiceClient _getBoardsByOrganizationIdGrpcServiceClient;
+    private readonly GetCardsByBoardIdGrpcServiceClient _getCardsByBoardIdGrpcServiceClient;
+    private readonly GetTasksByCardIdGrpcServiceClient _getTasksByCardIdGrpcServiceClient;
+    #endregion
+
+    #region Ctors
+
+    public GetOrganizationReportByIdHandler(OwnerReadDbContext ownerReadDbContext,
+        GetBoardsByOrganizationIdGrpcServiceClient getBoardsByOrganizationIdGrpcServiceClient,
+        GetCardsByBoardIdGrpcServiceClient getCardsByBoardIdGrpcServiceClient,
+        GetTasksByCardIdGrpcServiceClient getTasksByCardIdGrpcServiceClient,
+        IMapper mapper)
+        : base(mapper)
+    {
+        _ownerReadDbContext = ownerReadDbContext;
+        _getBoardsByOrganizationIdGrpcServiceClient = getBoardsByOrganizationIdGrpcServiceClient;
+        _getCardsByBoardIdGrpcServiceClient = getCardsByBoardIdGrpcServiceClient;
+        _getTasksByCardIdGrpcServiceClient = getTasksByCardIdGrpcServiceClient;
+    }
+
+    #endregion
+
+    #region Handlers
+
+
+
+    /// <summary>
+    ///
+    /// </summary>
+    public async Task<OrganizationReportDto> Handle(GetOrganizationReportByIdRequest request, CancellationToken cancellationToken)
+    {
+        var organizationReportDto = new OrganizationReportDto();
+        var organization = await _ownerReadDbContext.Organizations
+            .Find(e => e.Id == request.Id)
+            .FirstOrDefaultAsync(cancellationToken: cancellationToken);
+
+        if (organization == null)
+            throw new ApplicationException(ContractsMessages.Data_Not_exist, DomainMetadata.Organization);
+
+        #region Project Reports
+        var organizationProjects = await _ownerReadDbContext.Projects.Find(e => e.Id == organization.Id).ToListAsync(cancellationToken);
+        organizationReportDto.ProjectsCount = organizationProjects?.Count ?? 0;
+        #endregion
+
+        #region Board Reports
+        var boards = new List<GetBoardDto>();
+        var boardsGrpcCall = _getBoardsByOrganizationIdGrpcServiceClient.Handle(
+            new GetBoardsByOrganizationIdGrpcRequest { OrganizationId = organization.Id }
+        );
+
+        await foreach (var response in boardsGrpcCall.ResponseStream.ReadAllAsync())
+            boards.Add(_mapper.Map<GetBoardDto>(response));
+
+        organizationReportDto.BoardsCount = boards?.Count ?? 0;
+        #endregion
+
+        #region Task Reports
+        long toDoTasksCount = 0;
+        long doingTasksCount = 0;
+        long doneTasksCount = 0;
+        long backlogTasksCount = 0;
+
+        var allBoardTasks = await GetAllTasksForBoardsAsync(boards, cancellationToken);
+
+        foreach (var boardTask in allBoardTasks)
+        {
+            foreach (var cardTask in boardTask.CardTasks)
+            {
+                foreach (var task in cardTask.Tasks)
+                {
+                    switch (task.CardType)
+                    {
+                        case BoardCardType.ToDo:
+                            toDoTasksCount++;
+                            break;
+                        case BoardCardType.Doing:
+                            doingTasksCount++;
+                            break;
+                        case BoardCardType.Done:
+                            doneTasksCount++;
+                            break;
+                        case BoardCardType.Backlog:
+                            backlogTasksCount++;
+                            break;
+                    }
+                }
+            }
+        }
+
+        organizationReportDto.ToDoTasksCount = toDoTasksCount;
+        organizationReportDto.DoingTasksCount = doingTasksCount;
+        organizationReportDto.DoneTasksCount = doneTasksCount;
+        organizationReportDto.BacklogTasksCount = backlogTasksCount;
+
+
+        #endregion
+
+        return organizationReportDto;
+    }
+
+    #endregion
+
+    #region Private Methods
+    private async Task<IEnumerable<BoardTasksViewModel>> GetAllTasksForBoardsAsync(IEnumerable<GetBoardDto> boards, CancellationToken cancellationToken)
+    {
+        var boardTasks = new List<BoardTasksViewModel>();
+
+        foreach (var board in boards)
+        {
+            var cards = await GetCardsAsync(board.Id, cancellationToken);
+            var cardTasks = new List<CardDetailsViewModel>();
+
+            foreach (var card in cards)
+            {
+                var tasks = await GetTasksAsync(card.Card.Id);
+                cardTasks.Add(new CardDetailsViewModel
+                {
+                    Card = card.Card,
+                    Tasks = tasks
+                });
+            }
+
+            boardTasks.Add(new BoardTasksViewModel
+            {
+                Board = board,
+                CardTasks = cardTasks
+            });
+        }
+
+        return boardTasks;
+    }
+
+    public class BoardTasksViewModel
+    {
+        public GetBoardDto Board { get; set; }
+        public IEnumerable<CardDetailsViewModel> CardTasks { get; set; }
+    }
+
+    private async Task<IEnumerable<CardDetailsViewModel>> GetCardsAsync(string boardId, CancellationToken cancellationToken)
+    {
+        var cards = new List<CardDetailsViewModel>();
+
+        var cardsGrpcCall = _getCardsByBoardIdGrpcServiceClient.Handle(new GetCardsByBoardIdGrpcRequest { BoardId = boardId });
+
+        while (await cardsGrpcCall.ResponseStream.MoveNext(cancellationToken))
+        {
+            var currentCardGrpcResponse = cardsGrpcCall.ResponseStream.Current;
+
+            cards.Add(
+                new CardDetailsViewModel { Card = MapToCard(currentCardGrpcResponse), Tasks = await GetTasksAsync(currentCardGrpcResponse.Id), }
+            );
+        }
+
+        return cards.AsEnumerable();
+    }
+
+    private async Task<IEnumerable<GetTaskDto>> GetTasksAsync(string cardId)
+    {
+        var tasks = new List<GetTaskDto>();
+
+        var tasksGrpcCall = _getTasksByCardIdGrpcServiceClient.Handle(new GetTasksByCardIdGrpcRequest { CardId = cardId });
+
+        await foreach (var response in tasksGrpcCall.ResponseStream.ReadAllAsync())
+            tasks.Add(_mapper.Map<GetTaskDto>(response));
+
+        return tasks;
+    }
+
+    private GetCardDto MapToCard(GetCardGrpcResponse cardGrpcResponse)
+    {
+        return _mapper.Map<GetCardDto>(cardGrpcResponse);
+    }
+
+    #endregion
+}

--- a/src/2-Services/Owners/Api/Owners.Read.Api/Features/Organizations/GetOrganizationReportById/GetOrganizationReportByIdRequest.cs
+++ b/src/2-Services/Owners/Api/Owners.Read.Api/Features/Organizations/GetOrganizationReportById/GetOrganizationReportByIdRequest.cs
@@ -1,0 +1,15 @@
+﻿using TaskoMask.BuildingBlocks.Application.Queries;
+using TaskoMask.BuildingBlocks.Contracts.Dtos.Organizations;
+
+namespace TaskoMask.Services.Owners.Read.Api.Features.Organizations.GetOrganizationReportById;
+
+
+public class GetOrganizationReportByIdRequest : BaseQuery<OrganizationReportDto>
+{
+    public GetOrganizationReportByIdRequest(string id)
+    {
+        Id = id;
+    }
+
+    public string Id { get; }
+}

--- a/src/2-Services/Owners/Api/Owners.Read.Api/Features/Organizations/GetOrganizationReportById/GetOrganizationReportByIdRestEndpoint.cs
+++ b/src/2-Services/Owners/Api/Owners.Read.Api/Features/Organizations/GetOrganizationReportById/GetOrganizationReportByIdRestEndpoint.cs
@@ -1,0 +1,31 @@
+﻿using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Mvc;
+using System.Threading.Tasks;
+using TaskoMask.BuildingBlocks.Application.Bus;
+using TaskoMask.BuildingBlocks.Contracts.Dtos.Organizations;
+using TaskoMask.BuildingBlocks.Contracts.Helpers;
+using TaskoMask.BuildingBlocks.Contracts.Services;
+using TaskoMask.BuildingBlocks.Web.MVC.Controllers;
+
+namespace TaskoMask.Services.Owners.Read.Api.Features.Organizations.GetOrganizationReportById;
+
+
+
+[Authorize("user-read-access")]
+[Tags("Organizations")]
+public class GetOrganizationReportByIdRestEndpoint : BaseApiController
+{
+    public GetOrganizationReportByIdRestEndpoint(IAuthenticatedUserService authenticatedUserService, IInMemoryBus inMemoryBus)
+        : base(authenticatedUserService, inMemoryBus) { }
+
+    /// <summary>
+    /// get organization Report 
+    /// </summary>
+    [HttpGet]
+    [Route("organizations/report")]
+    public async Task<Result<OrganizationReportDto>> Get(string organizationId)
+    {
+        return await _inMemoryBus.SendQuery(new GetOrganizationReportByIdRequest(organizationId));
+    }
+}

--- a/src/2-Services/Owners/Api/Owners.Read.Api/Infrastructure/Mapper/MappingProfile.cs
+++ b/src/2-Services/Owners/Api/Owners.Read.Api/Infrastructure/Mapper/MappingProfile.cs
@@ -1,9 +1,13 @@
 ﻿using AutoMapper;
 using Google.Protobuf.WellKnownTypes;
+using System;
+using TaskoMask.BuildingBlocks.Contracts.Dtos.Boards;
+using TaskoMask.BuildingBlocks.Contracts.Dtos.Cards;
 using TaskoMask.BuildingBlocks.Contracts.Dtos.Common;
 using TaskoMask.BuildingBlocks.Contracts.Dtos.Organizations;
 using TaskoMask.BuildingBlocks.Contracts.Dtos.Owners;
 using TaskoMask.BuildingBlocks.Contracts.Dtos.Projects;
+using TaskoMask.BuildingBlocks.Contracts.Dtos.Tasks;
 using TaskoMask.BuildingBlocks.Contracts.Protos;
 using TaskoMask.Services.Owners.Read.Api.Domain;
 
@@ -23,6 +27,27 @@ public class MappingProfile : Profile
 
         CreateMap<Organization, GetOrganizationDto>();
 
+        CreateMap<GetBoardGrpcResponse, GetBoardDto>()
+            .ForMember(dest => dest.Description, opt => opt.MapFrom(src => src.Description ?? string.Empty))
+            .ForMember(dest => dest.Name, opt => opt.MapFrom(src => src.Name ?? string.Empty))
+            .ForMember(dest => dest.ProjectId, opt => opt.MapFrom(src => src.ProjectId ?? string.Empty))
+            .ForMember(dest => dest.OrganizationName, opt => opt.MapFrom(src => src.OrganizationName ?? string.Empty))
+            .ForMember(dest => dest.ProjectName, opt => opt.MapFrom(src => src.ProjectName ?? string.Empty))
+            .ForMember(dest => dest.OwnerId, opt => opt.MapFrom(src => src.OwnerId ?? string.Empty))
+            .ForMember(dest => dest.OrganizationId, opt => opt.MapFrom(src => src.OrganizationId ?? string.Empty));
+
+        CreateMap<CreationTimeGrpcResponse, CreationTimeDto>()
+            .ForMember(dest => dest.CreateDateTime, opt => opt.MapFrom(src => ConvertTimestamp(src.CreateDateTime)))
+            .ForMember(dest => dest.CreateDateTimeString, opt => opt.MapFrom(src => src.CreateDateTimeString ?? string.Empty))
+            .ForMember(dest => dest.ModifiedDateTime, opt => opt.MapFrom(src => ConvertTimestamp(src.ModifiedDateTime)))
+            .ForMember(dest => dest.ModifiedDateTimeString, opt => opt.MapFrom(src => src.ModifiedDateTimeString ?? string.Empty))
+            .ForMember(dest => dest.CreateDay, opt => opt.MapFrom(src => src.CreateDay))
+            .ForMember(dest => dest.CreateMonth, opt => opt.MapFrom(src => src.CreateMonth))
+            .ForMember(dest => dest.CreateYear, opt => opt.MapFrom(src => src.CreateYear));
+
+        CreateMap<GetCardGrpcResponse, GetCardDto>();
+        CreateMap<GetTaskGrpcResponse, GetTaskDto>();
+
         CreateMap<GetOrganizationDto, GetOrganizationGrpcResponse>()
             .ForMember(dest => dest.Description, opt => opt.MapFrom(src => src.Description ?? string.Empty));
 
@@ -30,5 +55,17 @@ public class MappingProfile : Profile
 
         CreateMap<GetProjectDto, GetProjectGrpcResponse>()
             .ForMember(dest => dest.Description, opt => opt.MapFrom(src => src.Description ?? string.Empty));
+    }
+
+    private DateTime? ConvertTimestamp(Timestamp timestamp)
+    {
+        try
+        {
+            return timestamp.ToDateTime();
+        }
+        catch
+        {
+            return null;
+        }
     }
 }

--- a/src/2-Services/Owners/Api/Owners.Read.Api/Infrastructure/Mapper/MappingProfile.cs
+++ b/src/2-Services/Owners/Api/Owners.Read.Api/Infrastructure/Mapper/MappingProfile.cs
@@ -19,6 +19,8 @@ public class MappingProfile : Profile
 
         CreateMap<Owner, GetOwnerDto>();
 
+        CreateMap<GetOrganizationReportGrpcResponse, OrganizationReportDto>();
+
         CreateMap<Organization, GetOrganizationDto>();
 
         CreateMap<GetOrganizationDto, GetOrganizationGrpcResponse>()

--- a/src/2-Services/Owners/Api/Owners.Read.Api/Owners.Read.Api.csproj
+++ b/src/2-Services/Owners/Api/Owners.Read.Api/Owners.Read.Api.csproj
@@ -31,8 +31,12 @@
 	<ItemGroup>
 		<Protobuf Include="..\..\..\..\1-BuildingBlocks\Contracts\Protos\base.proto" GrpcServices="Server" />
 		<Protobuf Include="..\..\..\..\1-BuildingBlocks\Contracts\Protos\get_organizations_by_owner_id.proto" GrpcServices="Server" />
+		<Protobuf Include="..\..\..\..\1-BuildingBlocks\Contracts\Protos\get_organizationReport_by_id.proto" GrpcServices="Server" />
 		<Protobuf Include="..\..\..\..\1-BuildingBlocks\Contracts\Protos\get_projects_by_organization_id.proto" GrpcServices="Server" />
 		<Protobuf Include="..\..\..\..\1-BuildingBlocks\Contracts\Protos\get_project_by_id.proto" GrpcServices="Server" />
+		<Protobuf Include="..\..\..\..\1-BuildingBlocks\Contracts\Protos\get_boards_by_organization_id.proto" GrpcServices="Client" />
+		<Protobuf Include="..\..\..\..\1-BuildingBlocks\Contracts\Protos\get_cards_by_board_id.proto" GrpcServices="Client" />
+		<Protobuf Include="..\..\..\..\1-BuildingBlocks\Contracts\Protos\get_tasks_by_card_id.proto" GrpcServices="Client" />
 	</ItemGroup>
 
 	<ItemGroup>

--- a/src/2-Services/Owners/Api/Owners.Read.Api/appsettings.json
+++ b/src/2-Services/Owners/Api/Owners.Read.Api/appsettings.json
@@ -9,6 +9,11 @@
     "UserName": "guest",
     "Password": "guest"
   },
+  "Url": {
+    "Owner-Read-Service": "https://localhost:5021",
+    "Board-Read-Service": "https://localhost:5025",
+    "Task-Read-Service": "https://localhost:5029"
+  },
   "Metric": {
     "StandAloneKestrelServerEnabled": false,
     "Port": 5021,

--- a/src/2-Services/Owners/Tests/Owners.Read.Tests.Integration/Features/Organizations/GetOrganizationReportByIdTests.cs
+++ b/src/2-Services/Owners/Tests/Owners.Read.Tests.Integration/Features/Organizations/GetOrganizationReportByIdTests.cs
@@ -1,0 +1,61 @@
+﻿using Moq;
+using TaskoMask.BuildingBlocks.Contracts.Protos;
+using TaskoMask.Services.Owners.Read.IntegrationTests.Fixtures;
+using Xunit;
+
+namespace TaskoMask.Services.Owners.Read.IntegrationTests.Features.Organizations;
+
+
+[Collection(nameof(OrganizationCollectionFixture))]
+public class GetOrganizationReportByIdTests
+{
+    #region Fields
+    private readonly OrganizationCollectionFixture _fixture;
+    private readonly Mock<GetBoardsByOrganizationIdGrpcService.GetBoardsByOrganizationIdGrpcServiceClient> _mockBoardsClient;
+    private readonly Mock<GetCardsByBoardIdGrpcService.GetCardsByBoardIdGrpcServiceClient> _mockCardsClient;
+    private readonly Mock<GetTasksByCardIdGrpcService.GetTasksByCardIdGrpcServiceClient> _mockTasksClient;
+    #endregion
+
+    #region Ctor
+    public GetOrganizationReportByIdTests(OrganizationCollectionFixture fixture)
+    {
+        _fixture = fixture;
+        _mockBoardsClient = new Mock<GetBoardsByOrganizationIdGrpcService.GetBoardsByOrganizationIdGrpcServiceClient>();
+        _mockCardsClient = new Mock<GetCardsByBoardIdGrpcService.GetCardsByBoardIdGrpcServiceClient>();
+        _mockTasksClient = new Mock<GetTasksByCardIdGrpcService.GetTasksByCardIdGrpcServiceClient>();
+    }
+
+    #endregion
+
+    #region Test Methods
+
+    //[Fact]
+    //public async Task OrganizationReport_are_fetched_by_Id()
+    //{
+    //    //Arrange
+    //    var expectedOrganization = OrganizationObjectMother.GetOrganization();
+    //    await _fixture.SeedOrganizationAsync(expectedOrganization);
+    //    var getOrganizationsReportByIdHandler = new GetOrganizationReportByIdHandler(
+    //            _fixture._dbContext,
+    //            _mockBoardsClient.Object,
+    //            _mockCardsClient.Object,
+    //            _mockTasksClient.Object,
+    //            _fixture._mapper
+    //        );
+    //    var request = new GetOrganizationReportByIdRequest(expectedOrganization.OwnerId);
+
+    //    //Act
+    //    var result = await getOrganizationsReportByIdHandler.Handle(request, CancellationToken.None);
+
+    //    //Assert
+    //    Assert.NotNull(result);
+    //    Assert.True(result.ProjectsCount >= 0);
+    //    Assert.True(result.BoardsCount >= 0);
+    //    Assert.True(result.ToDoTasksCount >= 0);
+    //    Assert.True(result.DoingTasksCount >= 0);
+    //    Assert.True(result.DoneTasksCount >= 0);
+    //    Assert.True(result.BacklogTasksCount >= 0);
+    //}
+
+    #endregion
+}

--- a/src/2-Services/Owners/Tests/Owners.Read.Tests.Integration/Features/Organizations/GetOrganizationReportByIdTests.cs
+++ b/src/2-Services/Owners/Tests/Owners.Read.Tests.Integration/Features/Organizations/GetOrganizationReportByIdTests.cs
@@ -1,6 +1,10 @@
-﻿using Moq;
+﻿using AutoBogus;
+using Grpc.Core;
+using Moq;
 using TaskoMask.BuildingBlocks.Contracts.Protos;
+using TaskoMask.Services.Owners.Read.Api.Features.Organizations.GetOrganizationReportById;
 using TaskoMask.Services.Owners.Read.IntegrationTests.Fixtures;
+using TaskoMask.Services.Owners.Read.IntegrationTests.TestData;
 using Xunit;
 
 namespace TaskoMask.Services.Owners.Read.IntegrationTests.Features.Organizations;
@@ -11,51 +15,113 @@ public class GetOrganizationReportByIdTests
 {
     #region Fields
     private readonly OrganizationCollectionFixture _fixture;
-    private readonly Mock<GetBoardsByOrganizationIdGrpcService.GetBoardsByOrganizationIdGrpcServiceClient> _mockBoardsClient;
-    private readonly Mock<GetCardsByBoardIdGrpcService.GetCardsByBoardIdGrpcServiceClient> _mockCardsClient;
-    private readonly Mock<GetTasksByCardIdGrpcService.GetTasksByCardIdGrpcServiceClient> _mockTasksClient;
+
     #endregion
 
     #region Ctor
     public GetOrganizationReportByIdTests(OrganizationCollectionFixture fixture)
     {
         _fixture = fixture;
-        _mockBoardsClient = new Mock<GetBoardsByOrganizationIdGrpcService.GetBoardsByOrganizationIdGrpcServiceClient>();
-        _mockCardsClient = new Mock<GetCardsByBoardIdGrpcService.GetCardsByBoardIdGrpcServiceClient>();
-        _mockTasksClient = new Mock<GetTasksByCardIdGrpcService.GetTasksByCardIdGrpcServiceClient>();
     }
 
     #endregion
 
     #region Test Methods
 
-    //[Fact]
-    //public async Task OrganizationReport_are_fetched_by_Id()
-    //{
-    //    //Arrange
-    //    var expectedOrganization = OrganizationObjectMother.GetOrganization();
-    //    await _fixture.SeedOrganizationAsync(expectedOrganization);
-    //    var getOrganizationsReportByIdHandler = new GetOrganizationReportByIdHandler(
-    //            _fixture._dbContext,
-    //            _mockBoardsClient.Object,
-    //            _mockCardsClient.Object,
-    //            _mockTasksClient.Object,
-    //            _fixture._mapper
-    //        );
-    //    var request = new GetOrganizationReportByIdRequest(expectedOrganization.OwnerId);
+    [Fact]
+    public async Task OrganizationReport_is_fetched_by_Id()
+    {
+        // Arrange
+        var expectedOrganization = OrganizationObjectMother.GetOrganization();
+        await _fixture.SeedOrganizationAsync(expectedOrganization);
 
-    //    //Act
-    //    var result = await getOrganizationsReportByIdHandler.Handle(request, CancellationToken.None);
+        var dbContext = _fixture._dbContext;
+        var mapper = _fixture._mapper;
 
-    //    //Assert
-    //    Assert.NotNull(result);
-    //    Assert.True(result.ProjectsCount >= 0);
-    //    Assert.True(result.BoardsCount >= 0);
-    //    Assert.True(result.ToDoTasksCount >= 0);
-    //    Assert.True(result.DoingTasksCount >= 0);
-    //    Assert.True(result.DoneTasksCount >= 0);
-    //    Assert.True(result.BacklogTasksCount >= 0);
-    //}
+        var mockBoardsClient = new Mock<GetBoardsByOrganizationIdGrpcService.GetBoardsByOrganizationIdGrpcServiceClient>();
+        var mockCardsClient = new Mock<GetCardsByBoardIdGrpcService.GetCardsByBoardIdGrpcServiceClient>();
+        var mockTasksClient = new Mock<GetTasksByCardIdGrpcService.GetTasksByCardIdGrpcServiceClient>();
 
+        // Setup mock responses
+        var fakeBoardsResponse = new AutoFaker<GetBoardGrpcResponse>().Generate();
+        var fakeCardsResponse = new AutoFaker<GetCardGrpcResponse>().Generate();
+        var fakeTasksResponse = new AutoFaker<GetTaskGrpcResponse>().Generate();
+
+
+        // Create AsyncServerStreamingCall<TResponse> objects for the mocked responses
+        var fakeBoardsAsyncResponse = new AsyncServerStreamingCall<GetBoardGrpcResponse>(
+            GetAsyncStreamReader(fakeBoardsResponse),
+            Task.FromResult(new Metadata()),
+            () => Status.DefaultSuccess,
+            () => new Metadata(),
+            () => { }
+        );
+
+
+        var fakeCardsAsyncResponse = new AsyncServerStreamingCall<GetCardGrpcResponse>(
+            GetAsyncStreamReader(fakeCardsResponse),
+            Task.FromResult(new Metadata()),
+            () => Status.DefaultSuccess,
+            () => new Metadata(),
+            () => { }
+        );
+
+        var fakeTasksAsyncResponse = new AsyncServerStreamingCall<GetTaskGrpcResponse>(
+            GetAsyncStreamReader(fakeTasksResponse),
+            Task.FromResult(new Metadata()),
+            () => Status.DefaultSuccess,
+            () => new Metadata(),
+            () => { }
+        );
+
+        mockBoardsClient.Setup(client => client.Handle(It.IsAny<GetBoardsByOrganizationIdGrpcRequest>(), null, null, CancellationToken.None))
+            .Returns(fakeBoardsAsyncResponse);
+
+        mockCardsClient.Setup(client => client.Handle(It.IsAny<GetCardsByBoardIdGrpcRequest>(), null, null, CancellationToken.None))
+            .Returns(fakeCardsAsyncResponse);
+
+        mockTasksClient.Setup(client => client.Handle(It.IsAny<GetTasksByCardIdGrpcRequest>(), null, null, CancellationToken.None))
+            .Returns(fakeTasksAsyncResponse);
+
+
+        var handler = new GetOrganizationReportByIdHandler(
+            dbContext,
+            mockBoardsClient.Object,
+            mockCardsClient.Object,
+            mockTasksClient.Object,
+            mapper
+        );
+
+        var request = new GetOrganizationReportByIdRequest(expectedOrganization.Id);
+
+        // Act
+        var result = await handler.Handle(request, CancellationToken.None);
+
+        // Assert
+        Assert.NotNull(result);
+        Assert.True(result.ProjectsCount >= 0);
+        Assert.True(result.BoardsCount >= 0);
+        Assert.True(result.ToDoTasksCount >= 0);
+        Assert.True(result.DoingTasksCount >= 0);
+        Assert.True(result.DoneTasksCount >= 0);
+        Assert.True(result.BacklogTasksCount >= 0);
+    }
+
+
+    #endregion
+
+    #region Methods
+    private static IAsyncStreamReader<T> GetAsyncStreamReader<T>(params T[] responses)
+    {
+        var mockStreamReader = new Mock<IAsyncStreamReader<T>>();
+        var queue = new Queue<T>(responses);
+
+        mockStreamReader.Setup(r => r.MoveNext(It.IsAny<CancellationToken>()))
+            .ReturnsAsync(() => queue.Count > 0);
+
+        mockStreamReader.Setup(r => r.Current).Returns(() => queue.Dequeue());
+
+        return mockStreamReader.Object;
+    }
     #endregion
 }

--- a/src/2-Services/Owners/Tests/Owners.Read.Tests.Integration/Fixtures/TestsBaseFixture.cs
+++ b/src/2-Services/Owners/Tests/Owners.Read.Tests.Integration/Fixtures/TestsBaseFixture.cs
@@ -1,6 +1,7 @@
 ﻿using AutoMapper;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
+using TaskoMask.BuildingBlocks.Application.Bus;
 using TaskoMask.BuildingBlocks.Test.TestBase;
 using TaskoMask.Services.Owners.Read.Api.Infrastructure.DbContext;
 using TaskoMask.Services.Owners.Read.Api.Infrastructure.DI;
@@ -11,12 +12,14 @@ public abstract class TestsBaseFixture : IntegrationTestsBase
 {
     public readonly IMapper _mapper;
     public readonly OwnerReadDbContext _dbContext;
+    public readonly IInMemoryBus _inMemoryBus;
 
     protected TestsBaseFixture(string dbNameSuffix)
         : base(dbNameSuffix)
     {
         _mapper = GetRequiredService<IMapper>();
         _dbContext = GetRequiredService<OwnerReadDbContext>();
+        _inMemoryBus = GetRequiredService<IInMemoryBus>();
     }
 
     /// <summary>
@@ -26,6 +29,7 @@ public abstract class TestsBaseFixture : IntegrationTestsBase
     {
         _serviceProvider.InitialDatabase();
     }
+
 
     /// <summary>
     ///

--- a/src/2-Services/Owners/Tests/Owners.Read.Tests.Integration/Owners.Read.Tests.Integration.csproj
+++ b/src/2-Services/Owners/Tests/Owners.Read.Tests.Integration/Owners.Read.Tests.Integration.csproj
@@ -10,6 +10,7 @@
 
 	<ItemGroup>
 		<PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.1.0" />
+		<PackageReference Include="Moq" Version="4.20.70" />
 		<PackageReference Include="xunit.runner.visualstudio" Version="2.4.3">
 			<IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
 			<PrivateAssets>all</PrivateAssets>

--- a/src/2-Services/Owners/Tests/Owners.Read.Tests.Integration/Owners.Read.Tests.Integration.csproj
+++ b/src/2-Services/Owners/Tests/Owners.Read.Tests.Integration/Owners.Read.Tests.Integration.csproj
@@ -9,6 +9,7 @@
 	</PropertyGroup>
 
 	<ItemGroup>
+		<PackageReference Include="AutoBogus" Version="2.13.1" />
 		<PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.1.0" />
 		<PackageReference Include="Moq" Version="4.20.70" />
 		<PackageReference Include="xunit.runner.visualstudio" Version="2.4.3">

--- a/src/3-ApiGateways/UserPanel/Aggregator/Aggregator.csproj
+++ b/src/3-ApiGateways/UserPanel/Aggregator/Aggregator.csproj
@@ -30,18 +30,19 @@
 	</ItemGroup>
 
 	<ItemGroup>
-		<Protobuf Include="..\..\..\1-BuildingBlocks\Contracts\Protos\base.proto" GrpcServices="Client"/>
-		<Protobuf Include="..\..\..\1-BuildingBlocks\Contracts\Protos\get_organizations_by_owner_id.proto" GrpcServices="Client"/>
-		<Protobuf Include="..\..\..\1-BuildingBlocks\Contracts\Protos\get_projects_by_organization_id.proto" GrpcServices="Client"/>
-		<Protobuf Include="..\..\..\1-BuildingBlocks\Contracts\Protos\get_project_by_id.proto" GrpcServices="Client"/>
-		<Protobuf Include="..\..\..\1-BuildingBlocks\Contracts\Protos\get_board_by_id.proto" GrpcServices="Client"/>
-		<Protobuf Include="..\..\..\1-BuildingBlocks\Contracts\Protos\get_boards_by_project_id.proto" GrpcServices="Client"/>
-		<Protobuf Include="..\..\..\1-BuildingBlocks\Contracts\Protos\get_boards_by_organization_id.proto" GrpcServices="Client"/>
-		<Protobuf Include="..\..\..\1-BuildingBlocks\Contracts\Protos\get_cards_by_board_id.proto" GrpcServices="Client"/>
+		<Protobuf Include="..\..\..\1-BuildingBlocks\Contracts\Protos\base.proto" GrpcServices="Client" />
+		<Protobuf Include="..\..\..\1-BuildingBlocks\Contracts\Protos\get_organizations_by_owner_id.proto" GrpcServices="Client" />
+		<Protobuf Include="..\..\..\1-BuildingBlocks\Contracts\Protos\get_projects_by_organization_id.proto" GrpcServices="Client" />
+		<Protobuf Include="..\..\..\1-BuildingBlocks\Contracts\Protos\get_project_by_id.proto" GrpcServices="Client" />
+		<Protobuf Include="..\..\..\1-BuildingBlocks\Contracts\Protos\get_board_by_id.proto" GrpcServices="Client" />
+		<Protobuf Include="..\..\..\1-BuildingBlocks\Contracts\Protos\get_boards_by_project_id.proto" GrpcServices="Client" />
+		<Protobuf Include="..\..\..\1-BuildingBlocks\Contracts\Protos\get_boards_by_organization_id.proto" GrpcServices="Client" />
+		<Protobuf Include="..\..\..\1-BuildingBlocks\Contracts\Protos\get_cards_by_board_id.proto" GrpcServices="Client" />
 		<Protobuf Include="..\..\..\1-BuildingBlocks\Contracts\Protos\get_task_by_id.proto" GrpcServices="Client" />
 		<Protobuf Include="..\..\..\1-BuildingBlocks\Contracts\Protos\get_comments_by_task_id.proto" GrpcServices="Client" />
 		<Protobuf Include="..\..\..\1-BuildingBlocks\Contracts\Protos\get_activities_by_task_id.proto" GrpcServices="Client" />
 		<Protobuf Include="..\..\..\1-BuildingBlocks\Contracts\Protos\get_tasks_by_card_id.proto" GrpcServices="Client" />
+		<Protobuf Include="..\..\..\1-BuildingBlocks\Contracts\Protos\get_organizationReport_by_id.proto" GrpcServices="Client" />
 	</ItemGroup>
 
 	<ItemGroup>

--- a/src/3-ApiGateways/UserPanel/Aggregator/Configuration/GrpcExtensions.cs
+++ b/src/3-ApiGateways/UserPanel/Aggregator/Configuration/GrpcExtensions.cs
@@ -4,6 +4,7 @@ using static TaskoMask.BuildingBlocks.Contracts.Protos.GetBoardsByOrganizationId
 using static TaskoMask.BuildingBlocks.Contracts.Protos.GetBoardsByProjectIdGrpcService;
 using static TaskoMask.BuildingBlocks.Contracts.Protos.GetCardsByBoardIdGrpcService;
 using static TaskoMask.BuildingBlocks.Contracts.Protos.GetCommentsByTaskIdGrpcService;
+using static TaskoMask.BuildingBlocks.Contracts.Protos.GetOrganizationReportIdGrpcService;
 using static TaskoMask.BuildingBlocks.Contracts.Protos.GetOrganizationsByOwnerIdGrpcService;
 using static TaskoMask.BuildingBlocks.Contracts.Protos.GetProjectByIdGrpcService;
 using static TaskoMask.BuildingBlocks.Contracts.Protos.GetProjectsByOrganizationIdGrpcService;
@@ -20,6 +21,11 @@ public static class GrpcExtensions
     public static void AddGrpcClients(this IServiceCollection services, IConfiguration configuration)
     {
         services.AddGrpcClient<GetOrganizationsByOwnerIdGrpcServiceClient>(options =>
+        {
+            options.Address = new Uri(configuration["Url:Owner-Read-Service"]);
+        });
+
+        services.AddGrpcClient<GetOrganizationReportIdGrpcServiceClient>(options =>
         {
             options.Address = new Uri(configuration["Url:Owner-Read-Service"]);
         });

--- a/src/3-ApiGateways/UserPanel/Aggregator/Features/GetOrganizationsByOwnerId/GetOrganizationsByOwnerIdHandler.cs
+++ b/src/3-ApiGateways/UserPanel/Aggregator/Features/GetOrganizationsByOwnerId/GetOrganizationsByOwnerIdHandler.cs
@@ -8,6 +8,7 @@ using TaskoMask.BuildingBlocks.Contracts.Dtos.Projects;
 using TaskoMask.BuildingBlocks.Contracts.Protos;
 using TaskoMask.BuildingBlocks.Contracts.ViewModels;
 using static TaskoMask.BuildingBlocks.Contracts.Protos.GetBoardsByOrganizationIdGrpcService;
+using static TaskoMask.BuildingBlocks.Contracts.Protos.GetOrganizationReportIdGrpcService;
 using static TaskoMask.BuildingBlocks.Contracts.Protos.GetOrganizationsByOwnerIdGrpcService;
 using static TaskoMask.BuildingBlocks.Contracts.Protos.GetProjectsByOrganizationIdGrpcService;
 
@@ -22,6 +23,8 @@ public class GetOrganizationsByOwnerIdHandler
     private readonly GetOrganizationsByOwnerIdGrpcServiceClient _getOrganizationsByOwnerIdGrpcServiceClient;
     private readonly GetProjectsByOrganizationIdGrpcServiceClient _getProjectsByOrganizationIdGrpcServiceClient;
     private readonly GetBoardsByOrganizationIdGrpcServiceClient _getBoardsByOrganizationIdGrpcServiceClient;
+    private readonly GetOrganizationReportIdGrpcServiceClient _getOrganizationReportIdGrpcServiceClient;
+
 
     #endregion
 
@@ -31,13 +34,15 @@ public class GetOrganizationsByOwnerIdHandler
         IMapper mapper,
         GetOrganizationsByOwnerIdGrpcServiceClient getOrganizationsByOwnerIdGrpcServiceClient,
         GetProjectsByOrganizationIdGrpcServiceClient getProjectsByOrganizationIdGrpcServiceClient,
-        GetBoardsByOrganizationIdGrpcServiceClient getBoardsByOrganizationIdGrpcServiceClient
+        GetBoardsByOrganizationIdGrpcServiceClient getBoardsByOrganizationIdGrpcServiceClient,
+        GetOrganizationReportIdGrpcServiceClient getOrganizationReportIdGrpcServiceClient
     )
         : base(mapper)
     {
         _getOrganizationsByOwnerIdGrpcServiceClient = getOrganizationsByOwnerIdGrpcServiceClient;
         _getProjectsByOrganizationIdGrpcServiceClient = getProjectsByOrganizationIdGrpcServiceClient;
         _getBoardsByOrganizationIdGrpcServiceClient = getBoardsByOrganizationIdGrpcServiceClient;
+        _getOrganizationReportIdGrpcServiceClient = getOrganizationReportIdGrpcServiceClient;
     }
 
     #endregion
@@ -67,8 +72,7 @@ public class GetOrganizationsByOwnerIdHandler
                     Organization = MapToOrganization(currentOrganizationGrpcResponse),
                     Projects = await GetProjectsAsync(currentOrganizationGrpcResponse.Id),
                     Boards = await GetBoardsAsync(currentOrganizationGrpcResponse.Id),
-                    //Will be done by issue #143
-                    Reports = new OrganizationReportDto(),
+                    Reports = await GetReportAsync(currentOrganizationGrpcResponse.Id, cancellationToken)
                 }
             );
         }
@@ -123,5 +127,17 @@ public class GetOrganizationsByOwnerIdHandler
         return boards;
     }
 
+
+    /// <summary>
+    ///
+    /// </summary>
+    private async Task<OrganizationReportDto> GetReportAsync(string organizationId, CancellationToken cancellationToken)
+    {
+        var reportGrpcResponse = await _getOrganizationReportIdGrpcServiceClient.HandleAsync(
+            new GetOrganizationReportIdGrpcRequest { OrganizationId = organizationId, },
+            cancellationToken: cancellationToken
+        );
+        return _mapper.Map<OrganizationReportDto>(reportGrpcResponse);
+    }
     #endregion
 }

--- a/src/3-ApiGateways/UserPanel/Aggregator/Infrastructure/Mapper/MappingProfile.cs
+++ b/src/3-ApiGateways/UserPanel/Aggregator/Infrastructure/Mapper/MappingProfile.cs
@@ -23,5 +23,7 @@ public class MappingProfile : Profile
         CreateMap<GetBoardGrpcResponse, GetBoardDto>();
 
         CreateMap<GetCardGrpcResponse, GetCardDto>();
+
+        CreateMap<GetOrganizationReportGrpcResponse, OrganizationReportDto>();
     }
 }

--- a/src/7-Docker/Infrastructure.yml
+++ b/src/7-Docker/Infrastructure.yml
@@ -39,7 +39,7 @@ services:
 
   mongo:
     container_name: mongo
-    image: mongo:4.4.6
+    image: mongo:latest
     restart: unless-stopped
     ports:
       - 27017:27017


### PR DESCRIPTION
This pull request implements the Get Reports for Organization details feature in Aggregator as per issue #143.

Changes:
Implemented the Get Reports for Organization details feature in Aggregator.
Added the necessary code to retrieve the reports for an organization =>
 (GetOrganizationReportById feature in owner.read.api)
 
Testing:
Unfortunately, I was unable to write unit tests for the GetOrganizationReportByIdHandler due to difficulties in handling the injection of clients. I would appreciate any guidance on how to properly test this handler.

Notes:
This feature is still in development and may require further testing and refinement before it is considered complete.
I would be happy to help with testing and refining this feature further.