### PR TITLE
update dockerfiles's to use .net 8 image

### DIFF
--- a/src/2-Services/Boards/Api/Boards.Read.Api/Dockerfile
+++ b/src/2-Services/Boards/Api/Boards.Read.Api/Dockerfile
@@ -1,11 +1,11 @@
 #See https://aka.ms/customizecontainer to learn how to customize your debug container and how Visual Studio uses this Dockerfile to build your images for faster debugging.
 
-FROM mcr.microsoft.com/dotnet/aspnet:6.0 AS base
+FROM mcr.microsoft.com/dotnet/aspnet:8.0 AS base
 WORKDIR /app
 EXPOSE 80
 EXPOSE 443
 
-FROM mcr.microsoft.com/dotnet/sdk:6.0 AS build
+FROM mcr.microsoft.com/dotnet/sdk:8.0 AS build
 WORKDIR /src
 COPY ["Directory.Build.props", "."]
 COPY ["src/2-Services/Boards/Api/Boards.Read.Api/Boards.Read.Api.csproj", "src/2-Services/Boards/Api/Boards.Read.Api/"]

--- a/src/2-Services/Boards/Api/Boards.Read.Api/Dockerfile.original
+++ b/src/2-Services/Boards/Api/Boards.Read.Api/Dockerfile.original
@@ -1,11 +1,11 @@
 #See https://aka.ms/containerfastmode to understand how Visual Studio uses this Dockerfile to build your images for faster debugging.
 
-FROM mcr.microsoft.com/dotnet/aspnet:6.0 AS base
+FROM mcr.microsoft.com/dotnet/aspnet:8.0 AS base
 WORKDIR /app
 EXPOSE 80
 EXPOSE 443
 
-FROM mcr.microsoft.com/dotnet/sdk:6.0 AS build
+FROM mcr.microsoft.com/dotnet/sdk:8.0 AS build
 WORKDIR /src
 COPY ["src/2-Services/Boards/Api/Boards.Read.Api/Boards.Read.Api.csproj", "src/2-Services/Boards/Api/Boards.Read.Api/"]
 COPY ["src/1-BuildingBlocks/Infrastructure/Infrastructure.csproj", "src/1-BuildingBlocks/Infrastructure/"]

--- a/src/2-Services/Boards/Api/Boards.Write.Api/Dockerfile
+++ b/src/2-Services/Boards/Api/Boards.Write.Api/Dockerfile
@@ -1,11 +1,11 @@
 #See https://aka.ms/customizecontainer to learn how to customize your debug container and how Visual Studio uses this Dockerfile to build your images for faster debugging.
 
-FROM mcr.microsoft.com/dotnet/aspnet:6.0 AS base
+FROM mcr.microsoft.com/dotnet/aspnet:8.0 AS base
 WORKDIR /app
 EXPOSE 80
 EXPOSE 443
 
-FROM mcr.microsoft.com/dotnet/sdk:6.0 AS build
+FROM mcr.microsoft.com/dotnet/sdk:8.0 AS build
 WORKDIR /src
 COPY ["Directory.Build.props", "."]
 COPY ["src/2-Services/Boards/Api/Boards.Write.Api/Boards.Write.Api.csproj", "src/2-Services/Boards/Api/Boards.Write.Api/"]

--- a/src/2-Services/Boards/Api/Boards.Write.Api/Dockerfile.original
+++ b/src/2-Services/Boards/Api/Boards.Write.Api/Dockerfile.original
@@ -1,11 +1,11 @@
 #See https://aka.ms/containerfastmode to understand how Visual Studio uses this Dockerfile to build your images for faster debugging.
 
-FROM mcr.microsoft.com/dotnet/aspnet:6.0 AS base
+FROM mcr.microsoft.com/dotnet/aspnet:8.0 AS base
 WORKDIR /app
 EXPOSE 80
 EXPOSE 443
 
-FROM mcr.microsoft.com/dotnet/sdk:6.0 AS build
+FROM mcr.microsoft.com/dotnet/sdk:8.0 AS build
 WORKDIR /src
 COPY ["src/2-Services/Boards/Api/Boards.Write.Api/Boards.Write.Api.csproj", "src/2-Services/Boards/Api/Boards.Write.Api/"]
 COPY ["src/1-BuildingBlocks/Web.MVC/Web.MVC.csproj", "src/1-BuildingBlocks/Web.MVC/"]

--- a/src/2-Services/Identity/Api/Identity.Api/Dockerfile
+++ b/src/2-Services/Identity/Api/Identity.Api/Dockerfile
@@ -1,11 +1,11 @@
 #See https://aka.ms/customizecontainer to learn how to customize your debug container and how Visual Studio uses this Dockerfile to build your images for faster debugging.
 
-FROM mcr.microsoft.com/dotnet/aspnet:6.0 AS base
+FROM mcr.microsoft.com/dotnet/aspnet:8.0 AS base
 WORKDIR /app
 EXPOSE 80
 EXPOSE 443
 
-FROM mcr.microsoft.com/dotnet/sdk:6.0 AS build
+FROM mcr.microsoft.com/dotnet/sdk:8.0 AS build
 WORKDIR /src
 COPY ["Directory.Build.props", "."]
 COPY ["src/2-Services/Identity/Api/Identity.Api/Identity.Api.csproj", "src/2-Services/Identity/Api/Identity.Api/"]

--- a/src/2-Services/Identity/Api/Identity.Api/Dockerfile.original
+++ b/src/2-Services/Identity/Api/Identity.Api/Dockerfile.original
@@ -1,11 +1,11 @@
 #See https://aka.ms/containerfastmode to understand how Visual Studio uses this Dockerfile to build your images for faster debugging.
 
-FROM mcr.microsoft.com/dotnet/aspnet:6.0 AS base
+FROM mcr.microsoft.com/dotnet/aspnet:8.0 AS base
 WORKDIR /app
 EXPOSE 80
 EXPOSE 443
 
-FROM mcr.microsoft.com/dotnet/sdk:6.0 AS build
+FROM mcr.microsoft.com/dotnet/sdk:8.0 AS build
 WORKDIR /src
 COPY ["src/2-Services/Identity/Api/Identity.Api/Identity.Api.csproj", "src/2-Services/Identity/Api/Identity.Api/"]
 COPY ["src/1-BuildingBlocks/Web.MVC/Web.MVC.csproj", "src/1-BuildingBlocks/Web.MVC/"]

--- a/src/2-Services/Owners/Api/Owners.Read.Api/Dockerfile
+++ b/src/2-Services/Owners/Api/Owners.Read.Api/Dockerfile
@@ -1,11 +1,11 @@
 #See https://aka.ms/customizecontainer to learn how to customize your debug container and how Visual Studio uses this Dockerfile to build your images for faster debugging.
 
-FROM mcr.microsoft.com/dotnet/aspnet:6.0 AS base
+FROM mcr.microsoft.com/dotnet/aspnet:8.0 AS base
 WORKDIR /app
 EXPOSE 80
 EXPOSE 443
 
-FROM mcr.microsoft.com/dotnet/sdk:6.0 AS build
+FROM mcr.microsoft.com/dotnet/sdk:8.0 AS build
 WORKDIR /src
 COPY ["Directory.Build.props", "."]
 COPY ["src/2-Services/Owners/Api/Owners.Read.Api/Owners.Read.Api.csproj", "src/2-Services/Owners/Api/Owners.Read.Api/"]

--- a/src/2-Services/Owners/Api/Owners.Read.Api/Dockerfile.original
+++ b/src/2-Services/Owners/Api/Owners.Read.Api/Dockerfile.original
@@ -1,11 +1,11 @@
 #See https://aka.ms/containerfastmode to understand how Visual Studio uses this Dockerfile to build your images for faster debugging.
 
-FROM mcr.microsoft.com/dotnet/aspnet:6.0 AS base
+FROM mcr.microsoft.com/dotnet/aspnet:8.0 AS base
 WORKDIR /app
 EXPOSE 80
 EXPOSE 443
 
-FROM mcr.microsoft.com/dotnet/sdk:6.0 AS build
+FROM mcr.microsoft.com/dotnet/sdk:8.0 AS build
 WORKDIR /src
 COPY ["src/2-Services/Owners/Api/Owners.Read.Api/Owners.Read.Api.csproj", "src/2-Services/Owners/Api/Owners.Read.Api/"]
 COPY ["src/1-BuildingBlocks/Infrastructure/Infrastructure.csproj", "src/1-BuildingBlocks/Infrastructure/"]

--- a/src/2-Services/Owners/Api/Owners.Write.Api/Dockerfile
+++ b/src/2-Services/Owners/Api/Owners.Write.Api/Dockerfile
@@ -1,11 +1,11 @@
 #See https://aka.ms/customizecontainer to learn how to customize your debug container and how Visual Studio uses this Dockerfile to build your images for faster debugging.
 
-FROM mcr.microsoft.com/dotnet/aspnet:6.0 AS base
+FROM mcr.microsoft.com/dotnet/aspnet:8.0 AS base
 WORKDIR /app
 EXPOSE 80
 EXPOSE 443
 
-FROM mcr.microsoft.com/dotnet/sdk:6.0 AS build
+FROM mcr.microsoft.com/dotnet/sdk:8.0 AS build
 WORKDIR /src
 COPY ["Directory.Build.props", "."]
 COPY ["src/2-Services/Owners/Api/Owners.Write.Api/Owners.Write.Api.csproj", "src/2-Services/Owners/Api/Owners.Write.Api/"]

--- a/src/2-Services/Owners/Api/Owners.Write.Api/Dockerfile.original
+++ b/src/2-Services/Owners/Api/Owners.Write.Api/Dockerfile.original
@@ -1,11 +1,11 @@
 #See https://aka.ms/containerfastmode to understand how Visual Studio uses this Dockerfile to build your images for faster debugging.
 
-FROM mcr.microsoft.com/dotnet/aspnet:6.0 AS base
+FROM mcr.microsoft.com/dotnet/aspnet:8.0 AS base
 WORKDIR /app
 EXPOSE 80
 EXPOSE 443
 
-FROM mcr.microsoft.com/dotnet/sdk:6.0 AS build
+FROM mcr.microsoft.com/dotnet/sdk:8.0 AS build
 WORKDIR /src
 COPY ["src/2-Services/Owners/Api/Owners.Write.Api/Owners.Write.Api.csproj", "src/2-Services/Owners/Api/Owners.Write.Api/"]
 COPY ["src/1-BuildingBlocks/Web.MVC/Web.MVC.csproj", "src/1-BuildingBlocks/Web.MVC/"]

--- a/src/2-Services/Tasks/Api/Tasks.Read.Api/Dockerfile
+++ b/src/2-Services/Tasks/Api/Tasks.Read.Api/Dockerfile
@@ -1,11 +1,11 @@
 #See https://aka.ms/customizecontainer to learn how to customize your debug container and how Visual Studio uses this Dockerfile to build your images for faster debugging.
 
-FROM mcr.microsoft.com/dotnet/aspnet:6.0 AS base
+FROM mcr.microsoft.com/dotnet/aspnet:8.0 AS base
 WORKDIR /app
 EXPOSE 80
 EXPOSE 443
 
-FROM mcr.microsoft.com/dotnet/sdk:6.0 AS build
+FROM mcr.microsoft.com/dotnet/sdk:8.0 AS build
 WORKDIR /src
 COPY ["Directory.Build.props", "."]
 COPY ["src/2-Services/Tasks/Api/Tasks.Read.Api/Tasks.Read.Api.csproj", "src/2-Services/Tasks/Api/Tasks.Read.Api/"]

--- a/src/2-Services/Tasks/Api/Tasks.Read.Api/Dockerfile.original
+++ b/src/2-Services/Tasks/Api/Tasks.Read.Api/Dockerfile.original
@@ -1,11 +1,11 @@
 #See https://aka.ms/containerfastmode to understand how Visual Studio uses this Dockerfile to build your images for faster debugging.
 
-FROM mcr.microsoft.com/dotnet/aspnet:6.0 AS base
+FROM mcr.microsoft.com/dotnet/aspnet:8.0 AS base
 WORKDIR /app
 EXPOSE 80
 EXPOSE 443
 
-FROM mcr.microsoft.com/dotnet/sdk:6.0 AS build
+FROM mcr.microsoft.com/dotnet/sdk:8.0 AS build
 WORKDIR /src
 COPY ["src/2-Services/Tasks/Api/Tasks.Read.Api/Tasks.Read.Api.csproj", "src/2-Services/Tasks/Api/Tasks.Read.Api/"]
 COPY ["src/1-BuildingBlocks/Infrastructure/Infrastructure.csproj", "src/1-BuildingBlocks/Infrastructure/"]

--- a/src/2-Services/Tasks/Api/Tasks.Write.Api/Dockerfile
+++ b/src/2-Services/Tasks/Api/Tasks.Write.Api/Dockerfile
@@ -1,11 +1,11 @@
 #See https://aka.ms/customizecontainer to learn how to customize your debug container and how Visual Studio uses this Dockerfile to build your images for faster debugging.
 
-FROM mcr.microsoft.com/dotnet/aspnet:6.0 AS base
+FROM mcr.microsoft.com/dotnet/aspnet:8.0 AS base
 WORKDIR /app
 EXPOSE 80
 EXPOSE 443
 
-FROM mcr.microsoft.com/dotnet/sdk:6.0 AS build
+FROM mcr.microsoft.com/dotnet/sdk:8.0 AS build
 WORKDIR /src
 COPY ["Directory.Build.props", "."]
 COPY ["src/2-Services/Tasks/Api/Tasks.Write.Api/Tasks.Write.Api.csproj", "src/2-Services/Tasks/Api/Tasks.Write.Api/"]

--- a/src/2-Services/Tasks/Api/Tasks.Write.Api/Dockerfile.original
+++ b/src/2-Services/Tasks/Api/Tasks.Write.Api/Dockerfile.original
@@ -1,11 +1,11 @@
 #See https://aka.ms/containerfastmode to understand how Visual Studio uses this Dockerfile to build your images for faster debugging.
 
-FROM mcr.microsoft.com/dotnet/aspnet:6.0 AS base
+FROM mcr.microsoft.com/dotnet/aspnet:8.0 AS base
 WORKDIR /app
 EXPOSE 80
 EXPOSE 443
 
-FROM mcr.microsoft.com/dotnet/sdk:6.0 AS build
+FROM mcr.microsoft.com/dotnet/sdk:8.0 AS build
 WORKDIR /src
 COPY ["src/2-Services/Tasks/Api/Tasks.Write.Api/Tasks.Write.Api.csproj", "src/2-Services/Tasks/Api/Tasks.Write.Api/"]
 COPY ["src/1-BuildingBlocks/Web.MVC/Web.MVC.csproj", "src/1-BuildingBlocks/Web.MVC/"]

--- a/src/3-ApiGateways/UserPanel/Aggregator/Dockerfile
+++ b/src/3-ApiGateways/UserPanel/Aggregator/Dockerfile
@@ -1,11 +1,11 @@
 #See https://aka.ms/customizecontainer to learn how to customize your debug container and how Visual Studio uses this Dockerfile to build your images for faster debugging.
 
-FROM mcr.microsoft.com/dotnet/aspnet:6.0 AS base
+FROM mcr.microsoft.com/dotnet/aspnet:8.0 AS base
 WORKDIR /app
 EXPOSE 80
 EXPOSE 443
 
-FROM mcr.microsoft.com/dotnet/sdk:6.0 AS build
+FROM mcr.microsoft.com/dotnet/sdk:8.0 AS build
 WORKDIR /src
 COPY ["Directory.Build.props", "."]
 COPY ["src/3-ApiGateways/UserPanel/Aggregator/Aggregator.csproj", "src/3-ApiGateways/UserPanel/Aggregator/"]

--- a/src/3-ApiGateways/UserPanel/Aggregator/Dockerfile.original
+++ b/src/3-ApiGateways/UserPanel/Aggregator/Dockerfile.original
@@ -1,11 +1,11 @@
 #See https://aka.ms/containerfastmode to understand how Visual Studio uses this Dockerfile to build your images for faster debugging.
 
-FROM mcr.microsoft.com/dotnet/aspnet:6.0 AS base
+FROM mcr.microsoft.com/dotnet/aspnet:8.0 AS base
 WORKDIR /app
 EXPOSE 80
 EXPOSE 443
 
-FROM mcr.microsoft.com/dotnet/sdk:6.0 AS build
+FROM mcr.microsoft.com/dotnet/sdk:8.0 AS build
 WORKDIR /src
 COPY ["src/3-ApiGateways/UserPanel/Aggregator/Aggregator.csproj", "src/3-ApiGateways/UserPanel/Aggregator/"]
 RUN dotnet restore "src/3-ApiGateways/UserPanel/Aggregator/Aggregator.csproj"

--- a/src/3-ApiGateways/UserPanel/ApiGateway/Dockerfile
+++ b/src/3-ApiGateways/UserPanel/ApiGateway/Dockerfile
@@ -1,11 +1,11 @@
 #See https://aka.ms/customizecontainer to learn how to customize your debug container and how Visual Studio uses this Dockerfile to build your images for faster debugging.
 
-FROM mcr.microsoft.com/dotnet/aspnet:6.0 AS base
+FROM mcr.microsoft.com/dotnet/aspnet:8.0 AS base
 WORKDIR /app
 EXPOSE 80
 EXPOSE 443
 
-FROM mcr.microsoft.com/dotnet/sdk:6.0 AS build
+FROM mcr.microsoft.com/dotnet/sdk:8.0 AS build
 WORKDIR /src
 COPY ["Directory.Build.props", "."]
 COPY ["src/3-ApiGateways/UserPanel/ApiGateway/ApiGateway.csproj", "src/3-ApiGateways/UserPanel/ApiGateway/"]

--- a/src/3-ApiGateways/UserPanel/ApiGateway/Dockerfile.original
+++ b/src/3-ApiGateways/UserPanel/ApiGateway/Dockerfile.original
@@ -1,11 +1,11 @@
 #See https://aka.ms/containerfastmode to understand how Visual Studio uses this Dockerfile to build your images for faster debugging.
 
-FROM mcr.microsoft.com/dotnet/aspnet:6.0 AS base
+FROM mcr.microsoft.com/dotnet/aspnet:8.0 AS base
 WORKDIR /app
 EXPOSE 80
 EXPOSE 443
 
-FROM mcr.microsoft.com/dotnet/sdk:6.0 AS build
+FROM mcr.microsoft.com/dotnet/sdk:8.0 AS build
 WORKDIR /src
 COPY ["src/3-ApiGateways/UserPanel/ApiGateway/ApiGateway.csproj", "src/3-ApiGateways/UserPanel/ApiGateway/"]
 COPY ["src/1-BuildingBlocks/Web.MVC/Web.MVC.csproj", "src/1-BuildingBlocks/Web.MVC/"]

--- a/src/4-Clients/UserPanel/Dockerfile
+++ b/src/4-Clients/UserPanel/Dockerfile
@@ -1,4 +1,4 @@
-FROM mcr.microsoft.com/dotnet/sdk:6.0 AS build
+FROM mcr.microsoft.com/dotnet/sdk:8.0 AS build
 
 WORKDIR /src
 COPY ["src/4-Clients/UserPanel/UserPanel.csproj", "src/4-Clients/UserPanel/"]

--- a/src/4-Clients/Website/Dockerfile
+++ b/src/4-Clients/Website/Dockerfile
@@ -1,11 +1,11 @@
 #See https://aka.ms/customizecontainer to learn how to customize your debug container and how Visual Studio uses this Dockerfile to build your images for faster debugging.
 
-FROM mcr.microsoft.com/dotnet/aspnet:6.0 AS base
+FROM mcr.microsoft.com/dotnet/aspnet:8.0 AS base
 WORKDIR /app
 EXPOSE 80
 EXPOSE 443
 
-FROM mcr.microsoft.com/dotnet/sdk:6.0 AS build
+FROM mcr.microsoft.com/dotnet/sdk:8.0 AS build
 WORKDIR /src
 COPY ["Directory.Build.props", "."]
 COPY ["src/4-Clients/Website/Website.csproj", "src/4-Clients/Website/"]

--- a/src/4-Clients/Website/Dockerfile.original
+++ b/src/4-Clients/Website/Dockerfile.original
@@ -1,11 +1,11 @@
 #See https://aka.ms/containerfastmode to understand how Visual Studio uses this Dockerfile to build your images for faster debugging.
 
-FROM mcr.microsoft.com/dotnet/aspnet:6.0 AS base
+FROM mcr.microsoft.com/dotnet/aspnet:8.0 AS base
 WORKDIR /app
 EXPOSE 80
 EXPOSE 443
 
-FROM mcr.microsoft.com/dotnet/sdk:6.0 AS build
+FROM mcr.microsoft.com/dotnet/sdk:8.0 AS build
 WORKDIR /src
 COPY ["src/4-Clients/Website/Website.csproj", "src/4-Clients/Website/"]
 COPY ["src/1-BuildingBlocks/Web.MVC/Web.MVC.csproj", "src/1-BuildingBlocks/Web.MVC/"]


### PR DESCRIPTION
update dockerfiles's to use .net 8 image to avoid docker build errors
[#178](https://github.com/hamed-shirbandi/TaskoMask/issues/178)